### PR TITLE
Fix false syntax errors in tokenize so CSS shorthand properties with …

### DIFF
--- a/lib/tokenize.js
+++ b/lib/tokenize.js
@@ -20,6 +20,7 @@ const at = '@'.charCodeAt(0);
 const atEnd = /[ \n\t\r\{\(\)'"\\;,/]/g;
 const wordEnd = /[ \n\t\r\(\)\*:;@!&'"\+\|~>,\[\]\\]|\/(?=\*)/g;
 const wordEndNum = /[ \n\t\r\(\)\*:;@!&'"\-\+\|~>,\[\]\\]|\//g;
+const trailingUnit = /[0-9][A-Za-z]+$/g;
 
 const util = require('util');
 const TokenizeError = require('./errors/TokenizeError');
@@ -189,7 +190,10 @@ module.exports = function tokenize (input) {
         next = pos + 1;
         nextChar = css.slice(pos + 1, next + 1);
 
-        let prevChar = css.slice(pos - 1, pos);
+        let prevChar = css.slice(pos - 1, pos),
+          plusOrMinus = (code === plus || code === minus),
+          leadingSpace = prevChar.charCodeAt(0) === space,
+          trailingSpace = nextChar.charCodeAt(0) === space;
 
         // if the operator is immediately followed by a word character, then we
         // have a prefix of some kind, and should fall-through. eg. -webkit
@@ -209,14 +213,23 @@ module.exports = function tokenize (input) {
         }
 
         // if a +|- operator is followed by a non-word character (. is allowed) and
-        // is preceded by a non-word character. (5+5)
-        if (pos > 0 && (code === plus || code === minus)) {
-          if (prevChar.charCodeAt(0) !== space) {
+        // is preceded by a non-word character.
+        if (pos > 0 && plusOrMinus) {
+          let precedingText = css.slice(0, pos).trim();
+
+          // (e.g. 16px- 16px)
+          if (!leadingSpace) {
             tokenizeError();
           }
-          else if (nextChar.charCodeAt(0) !== space) {
+          // (e.g. 5 -5px)
+          else if (leadingSpace && !trailingUnit.test(precedingText) && !trailingSpace) {
             tokenizeError();
           }
+        }
+
+        // (e.g. - 16px)
+        if (pos === 0 && plusOrMinus && trailingSpace) {
+          tokenizeError();
         }
 
         /* eslint no-fallthrough: 0 */

--- a/test/function.js
+++ b/test/function.js
@@ -104,6 +104,16 @@ describe('Parser → Function', () => {
         { type: 'number', value: '0' },
         { type: 'paren', value: ')' }
       ]
+    },
+    {
+      it: 'should parse shorthand properties with negative values',
+      test: '-1px -2px -3px -4px',
+      expected: [
+        { type: 'number', value: '-1', unit: 'px' },
+        { type: 'number', value: '-2', unit: 'px' },
+        { type: 'number', value: '-3', unit: 'px' },
+        { type: 'number', value: '-4', unit: 'px' }
+      ]
     }
   ];
 

--- a/test/tokenize.js
+++ b/test/tokenize.js
@@ -2,10 +2,16 @@
 
 const expect = require('chai').expect;
 const tokenize = require('../lib/tokenize');
+const TokenizeError = require('../lib/errors/TokenizeError');
 
 describe('Tokenize', () => {
 
-  let fixtures = [
+  const passes = [
+    { value: '5 + 5', expectedLength: 5 },
+    { value: '#ffffff', expectedLength: 1 },
+    { value: '-16px', expectedLength: 1 },
+    { value: '-16px -1px -1px -16px', expectedLength: 7 },
+    { value: '-webkit-transform cubic-bezier(0,.9,.05,1)', expectedLength: 12 },
     { value: '#ffffff', expectedLength: 1 },
     { value: '#fff #000 #ccc #ddd', expectedLength: 7 },
     { value: '( calc(( ) ))word', expectedLength: 11 },
@@ -14,14 +20,30 @@ describe('Tokenize', () => {
     { value: '#ffffff', expectedLength: 1 },
     { value: 'Bond\\ 007', expectedLength: 4 },
     { value: ' \\"word\\\'"\\ \\\t ', expectedLength: 7 },
+    { value: 'bar(baz(black, 10%), 10%)', expectedLength: 13 },
     { value: 'bar(baz(black, 10%), 10%)', expectedLength: 13 }
   ];
 
-  fixtures.forEach((fixture) => {
+  passes.forEach((fixture) => {
     it('should tokenize ' + fixture.value.replace(/\n/g, '\\n').replace(/\t/g, '\\t'), () => {
-      let tokens = tokenize(fixture.value);
+      const tokens = tokenize(fixture.value);
 
       expect(tokens.length).to.equal(fixture.expectedLength);
     });
   });
+
+  const failures = [
+    '5 +5',
+    '5 -5px',
+    '- 16px',
+    '16px- 16px'
+  ];
+
+  failures.forEach((fixture) => {
+    it('should throw a TokenizeError error ' + fixture, () => {
+      const fn = () => tokenize(fixture);
+      expect(fn).to.throw(TokenizeError);
+    });
+  });
+
 });


### PR DESCRIPTION
Fixes a bug in `tokenize.js` where a syntax error was being thrown for CSS shorthand properties with negative values (e.g. `margin: -1px -1px -1px -1x`).